### PR TITLE
 graceful counterpart to http.Server methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ func main() {
 }
 ```
 
+In addition to Run there are the http.Server counterparts ListenAndServe, ListenAndServeTLS and Serve, these allow to configure https, custom timeouts and error handling.
 
 
 When Graceful is sent a SIGINT (ctrl+c), it:


### PR DESCRIPTION
this pull request adds three new API functions that pose the graceful counterpart to http.Server methods.
the use cases for this change is obvious, but i am not sure if the new API is not too crowded as a result.
maybe only the Serve method would suffice? please do think about what balance of convenience and feature completeness is reasonable.
