### PR TITLE
Add NotifyClosed for signaling when hijacked connections are closed.

### DIFF
--- a/graceful.go
+++ b/graceful.go
@@ -250,3 +250,11 @@ func (srv *Server) StopChan() <-chan stop.Signal {
 	})
 	return srv.stopChan
 }
+
+// NotifyClosed tells the connection tracking goroutine that
+// a connection has closed. Hijacked connections no longer
+// notify the server of changes to the connection via the ConnState
+// callback, so the Server must be manually notified.
+func (srv *Server) NotifyClosed(conn net.Conn) {
+	srv.Server.ConnState(conn, http.StateClosed)
+}

--- a/graceful_test.go
+++ b/graceful_test.go
@@ -239,3 +239,55 @@ func TestGracefulExplicitStopOverride(t *testing.T) {
 		t.Fatal("Timed out while waiting for explicit stop to complete")
 	}
 }
+
+func hijackingListener(srv *Server) (*http.Server, net.Listener, error) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
+		conn, bufrw, err := rw.(http.Hijacker).Hijack()
+		if err != nil {
+			http.Error(rw, "webserver doesn't support hijacking", http.StatusInternalServerError)
+			return
+		}
+
+		defer conn.Close()
+		defer srv.NotifyClosed(conn)
+
+		bufrw.WriteString("HTTP/1.1 200 OK\r\n\r\n")
+		bufrw.Flush()
+	})
+
+	server := &http.Server{Addr: ":3000", Handler: mux}
+	l, err := net.Listen("tcp", ":3000")
+	return server, l, err
+}
+
+func TestNotifyClosed(t *testing.T) {
+	c := make(chan os.Signal, 1)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	srv := &Server{Timeout: killTime, interrupt: c}
+	server, l, err := hijackingListener(srv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv.Server = server
+
+	go func() {
+		srv.Serve(l)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go launchTestQueries(t, &wg, c)
+
+	// block on the stopChan until the server has shut down
+	select {
+	case <-srv.StopChan():
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Timed out while waiting for explicit stop to complete")
+	}
+
+}


### PR DESCRIPTION
Hijacked http connection no longer notify the server of changes to the connection via the ConnState callback. NotifyClosed will place the connection in the remove channel so that it is recorded as closed.
