### PR TITLE
Use LimitListener if a limit is specified

### DIFF
--- a/graceful.go
+++ b/graceful.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/pat/stop"
+	"code.google.com/p/go.net/netutil"
 )
 
 // Server wraps an http.Server with graceful connection handling.
@@ -30,6 +31,9 @@ type Server struct {
 	// Timeout is the duration to allow outstanding requests to survive
 	// before forcefully terminating them.
 	Timeout time.Duration
+
+	// Limit the number of outstanding requests
+	ListenLimit int
 
 	// ConnState specifies an optional callback function that is
 	// called when a client connection changes state. This is a proxy
@@ -100,6 +104,9 @@ func (srv *Server) ListenAndServe() error {
 		return err
 	}
 
+	if srv.ListenLimit != 0 {
+		l = netutil.LimitListener(l, srv.ListenLimit)
+	}
 	return srv.Serve(l)
 }
 


### PR DESCRIPTION
Go's net/http library creates a goroutine for every request which if an
application does not finish processing requests quickly enough, many
goroutines can be created allocation quite a bit of memory.  By using
the LimitListener we can limit the number of concurrent requests being
processed.
