### PR TITLE
Add `RunWithErr` function.

### DIFF
--- a/graceful.go
+++ b/graceful.go
@@ -91,6 +91,19 @@ func Run(addr string, timeout time.Duration, n http.Handler) {
 
 }
 
+// RunWithErr is an alternative version of Run function which can return error.
+//
+// Unlike Run this version will not exit the program if an error is encountered but will
+// return it instead.
+func RunWithErr(addr string, timeout time.Duration, n http.Handler) error {
+	srv := &Server{
+		Timeout: timeout,
+		Server:  &http.Server{Addr: addr, Handler: n},
+	}
+
+	return srv.ListenAndServe()
+}
+
 // ListenAndServe is equivalent to http.Server.ListenAndServe with graceful shutdown enabled.
 //
 // timeout is the duration to wait until killing active requests and stopping the server.


### PR DESCRIPTION
The code in question is [here](https://github.com/tylerb/graceful/blob/master/graceful.go#L86-L89).

```go
if err := srv.ListenAndServe(); err != nil {
	if opErr, ok := err.(*net.OpError); !ok || (ok && opErr.Op != "accept") {
		logger := log.New(os.Stdout, "[graceful] ", 0)
		logger.Fatal(err)
	}
}
```

Why doesn't `Run` just return an error and let the user of this library decide how to handle it?

It's not that big issue of course, but one of the reasons why I moved away from `facebookgo/grace` is because it also uses logger, just more often than `graceful`.