### PR TITLE
Always create listening socket in main test thread

### DIFF
--- a/graceful_test.go
+++ b/graceful_test.go
@@ -82,22 +82,11 @@ func createListener(sleep time.Duration) (*http.Server, net.Listener, error) {
 		rw.WriteHeader(http.StatusOK)
 	})
 
-	time.Sleep(1 * time.Second)
 	server := &http.Server{Addr: ":9654", Handler: mux}
 	l, err := net.Listen("tcp", ":9654")
 	if err != nil {
 	}
 	return server, l, err
-}
-
-func runServer(timeout, sleep time.Duration, c chan os.Signal) error {
-	server, l, err := createListener(sleep)
-	if err != nil {
-		return err
-	}
-
-	srv := &Server{Timeout: timeout, Server: server, interrupt: c}
-	return srv.Serve(l)
 }
 
 func launchTestQueries(t *testing.T, wg *sync.WaitGroup, c chan os.Signal) {
@@ -123,11 +112,16 @@ func TestGracefulRun(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
+	server, l, err := createListener(killTime / 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	go func() {
-		runServer(killTime, killTime/2, c)
+		srv := &Server{Timeout: killTime, Server: server, interrupt: c}
+		srv.Serve(l)
 		wg.Done()
 	}()
-	time.Sleep(1 * time.Second)
 
 	wg.Add(1)
 	go launchTestQueries(t, &wg, c)
@@ -140,11 +134,16 @@ func TestGracefulRunTimesOut(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
+	server, l, err := createListener(killTime * 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	go func() {
-		runServer(killTime, killTime*10, c)
+		srv := &Server{Timeout: killTime, Server: server, interrupt: c}
+		srv.Serve(l)
 		wg.Done()
 	}()
-	time.Sleep(2 * time.Second)
 
 	var once sync.Once
 	wg.Add(1)
@@ -171,11 +170,16 @@ func TestGracefulRunDoesntTimeOut(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
+	server, l, err := createListener(killTime * 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	go func() {
-		runServer(0, killTime*2, c)
+		srv := &Server{Timeout: 0, Server: server, interrupt: c}
+		srv.Serve(l)
 		wg.Done()
 	}()
-	time.Sleep(1 * time.Second)
 
 	wg.Add(1)
 	go launchTestQueries(t, &wg, c)
@@ -188,11 +192,16 @@ func TestGracefulRunNoRequests(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
+	server, l, err := createListener(killTime * 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	go func() {
-		runServer(0, killTime*2, c)
+		srv := &Server{Timeout: 0, Server: server, interrupt: c}
+		srv.Serve(l)
 		wg.Done()
 	}()
-	time.Sleep(1 * time.Second)
 
 	c <- os.Interrupt
 
@@ -220,8 +229,12 @@ func TestGracefulForwardsConnState(t *testing.T) {
 		http.StateClosed: 8,
 	}
 
+	server, l, err := createListener(killTime / 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	go func() {
-		server, l, _ := createListener(killTime / 2)
 		srv := &Server{
 			ConnState: connState,
 			Timeout:   killTime,
@@ -232,7 +245,6 @@ func TestGracefulForwardsConnState(t *testing.T) {
 
 		wg.Done()
 	}()
-	time.Sleep(2 * time.Second)
 
 	wg.Add(1)
 	go launchTestQueries(t, &wg, c)


### PR DESCRIPTION
This resolves a race condition between spawning the listening server
and performing client queries, which caused the tests to fail with
the error "No response when a response was expected".

Fix #61