### PR TITLE
Make handling of multiple interrupt signals idempotent.

### DIFF
--- a/graceful_test.go
+++ b/graceful_test.go
@@ -1,8 +1,10 @@
 package graceful
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -455,5 +457,65 @@ func TestStopRace(t *testing.T) {
 	case <-srv.StopChan():
 	case <-time.After(timeoutTime):
 		t.Fatal("Timed out while waiting for explicit stop to complete")
+	}
+}
+
+func TestInterruptLog(t *testing.T) {
+	c := make(chan os.Signal, 1)
+
+	server, l, err := createListener(killTime * 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	var tbuf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+	expected := log.New(&tbuf, "", 0)
+
+	srv := &Server{Timeout: killTime, Server: server, Logger: logger, interrupt: c}
+	go func() { srv.Serve(l) }()
+
+	stop := srv.StopChan()
+	c <- os.Interrupt
+	expected.Print("shutdown initiated")
+
+	<-stop
+
+	if buf.String() != tbuf.String() {
+		t.Fatal("shutdown log incorrect - got '" + buf.String() + "'")
+	}
+}
+
+func TestMultiInterrupts(t *testing.T) {
+	c := make(chan os.Signal, 1)
+
+	server, l, err := createListener(killTime * 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	var tbuf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+	expected := log.New(&tbuf, "", 0)
+
+	srv := &Server{Timeout: killTime, Server: server, Logger: logger, interrupt: c}
+	go func() { srv.Serve(l) }()
+
+	stop := srv.StopChan()
+	c <- os.Interrupt
+	expected.Printf("shutdown initiated")
+	for i := 0; i < 10; i++ {
+		c <- os.Interrupt
+		expected.Printf("already shutting down")
+	}
+
+	<-stop
+
+	for i, b := range buf.Bytes() {
+		if b != tbuf.Bytes()[i] {
+			t.Fatal(fmt.Sprintf("shutdown log incorrect - got '%s', expected '%s'", buf.String(), tbuf.String()))
+		}
 	}
 }


### PR DESCRIPTION
This PR changes the interrupt handler so that it does
not unregister itself after handling a signal. Instead it
now logs duplicate signals and otherwise ignores them.

The commit also logs errors that occur when closing the 
listener instead of ignoring them.