### PR TITLE
Fix limit keepalive

### DIFF
--- a/graceful.go
+++ b/graceful.go
@@ -10,8 +10,6 @@ import (
 	"sync"
 	"syscall"
 	"time"
-
-	"golang.org/x/net/netutil"
 )
 
 // Server wraps an http.Server with graceful connection handling.
@@ -235,7 +233,7 @@ func Serve(server *http.Server, l net.Listener, timeout time.Duration) error {
 func (srv *Server) Serve(listener net.Listener) error {
 
 	if srv.ListenLimit != 0 {
-		listener = netutil.LimitListener(listener, srv.ListenLimit)
+		listener = LimitListener(listener, srv.ListenLimit)
 	}
 
 	if srv.TCPKeepAlive != 0 {

--- a/graceful.go
+++ b/graceful.go
@@ -437,29 +437,3 @@ func (srv *Server) shutdown(shutdown chan chan struct{}, kill chan struct{}) {
 	}
 	srv.chanLock.Unlock()
 }
-
-type keepAliveConn interface {
-	SetKeepAlive(bool) error
-	SetKeepAlivePeriod(d time.Duration) error
-}
-
-// keepAliveListener sets TCP keep-alive timeouts on accepted
-// connections. It's used by ListenAndServe and ListenAndServeTLS so
-// dead TCP connections (e.g. closing laptop mid-download) eventually
-// go away.
-type keepAliveListener struct {
-	net.Listener
-	keepAlivePeriod time.Duration
-}
-
-func (ln keepAliveListener) Accept() (net.Conn, error) {
-	c, err := ln.Listener.Accept()
-	if err != nil {
-		return nil, err
-	}
-
-	kac := c.(keepAliveConn)
-	kac.SetKeepAlive(true)
-	kac.SetKeepAlivePeriod(ln.keepAlivePeriod)
-	return c, nil
-}

--- a/graceful_test.go
+++ b/graceful_test.go
@@ -21,12 +21,9 @@ const (
 	// The tests will run a test server on this port.
 	port               = 9654
 	concurrentRequestN = 8
-)
-
-var (
-	killTime    = 500 * time.Millisecond
-	timeoutTime = 1000 * time.Millisecond
-	waitTime    = 100 * time.Millisecond
+	killTime           = 500 * time.Millisecond
+	timeoutTime        = 1000 * time.Millisecond
+	waitTime           = 100 * time.Millisecond
 )
 
 func runQuery(t *testing.T, expected int, shouldErr bool, wg *sync.WaitGroup, once *sync.Once) {

--- a/keepalive_listener.go
+++ b/keepalive_listener.go
@@ -1,0 +1,32 @@
+package graceful
+
+import (
+	"net"
+	"time"
+)
+
+type keepAliveConn interface {
+	SetKeepAlive(bool) error
+	SetKeepAlivePeriod(d time.Duration) error
+}
+
+// keepAliveListener sets TCP keep-alive timeouts on accepted
+// connections. It's used by ListenAndServe and ListenAndServeTLS so
+// dead TCP connections (e.g. closing laptop mid-download) eventually
+// go away.
+type keepAliveListener struct {
+	net.Listener
+	keepAlivePeriod time.Duration
+}
+
+func (ln keepAliveListener) Accept() (net.Conn, error) {
+	c, err := ln.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	kac := c.(keepAliveConn)
+	kac.SetKeepAlive(true)
+	kac.SetKeepAlivePeriod(ln.keepAlivePeriod)
+	return c, nil
+}

--- a/limit_listen.go
+++ b/limit_listen.go
@@ -1,0 +1,56 @@
+// Copyright 2013 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graceful
+
+import (
+	"net"
+	"sync"
+)
+
+// LimitListener returns a Listener that accepts at most n simultaneous
+// connections from the provided Listener.
+func LimitListener(l net.Listener, n int) net.Listener {
+	return &limitListener{l, make(chan struct{}, n)}
+}
+
+type limitListener struct {
+	net.Listener
+	sem chan struct{}
+}
+
+func (l *limitListener) acquire() { l.sem <- struct{}{} }
+func (l *limitListener) release() { <-l.sem }
+
+func (l *limitListener) Accept() (net.Conn, error) {
+	l.acquire()
+	c, err := l.Listener.Accept()
+	if err != nil {
+		l.release()
+		return nil, err
+	}
+	return &limitListenerConn{Conn: c, release: l.release}, nil
+}
+
+type limitListenerConn struct {
+	net.Conn
+	releaseOnce sync.Once
+	release     func()
+}
+
+func (l *limitListenerConn) Close() error {
+	err := l.Conn.Close()
+	l.releaseOnce.Do(l.release)
+	return err
+}


### PR DESCRIPTION
This change allows to use `LimitListen` and `KeepAlive` option together without `panic`'ing. It follows the same idea that what used in https://github.com/coreos/etcd/pull/4174/files .

Fixes #79.