### PR TITLE
Fix data-race on kill event destructing ConnState

### DIFF
--- a/graceful.go
+++ b/graceful.go
@@ -259,6 +259,10 @@ func (srv *Server) Serve(listener net.Listener) error {
 		case http.StateClosed, http.StateHijacked:
 			remove <- conn
 		}
+
+		srv.stopLock.Lock()
+		defer srv.stopLock.Unlock()
+
 		if srv.ConnState != nil {
 			srv.ConnState(conn, state)
 		}
@@ -364,6 +368,9 @@ func (srv *Server) manageConnections(add, idle, remove chan net.Conn, shutdown c
 				}
 			}
 		case <-kill:
+			srv.stopLock.Lock()
+			defer srv.stopLock.Unlock()
+
 			srv.Server.ConnState = nil
 			for k := range srv.connections {
 				if err := k.Close(); err != nil {


### PR DESCRIPTION
It seems graceful's server can panic on shutdown in less likely events, but it's good to never allow this.

I haven't tested this thoroughly, as I am not too familiar yet with the relations between `Stop`, `kill`, `shutdown`, etc. but it seems to fix the issue without introducing regressions (e.g. deadlock).

```
$ go test -race .
==================
WARNING: DATA RACE
Write by goroutine 76:
  _/Users/abc/dev/graceful.(*Server).manageConnections()
      /Users/abc/dev/graceful/graceful.go:367 +0x839

Previous read by goroutine 108:
  net/http.(*conn).setState()
      /usr/local/Cellar/go/1.6.2/libexec/src/net/http/server.go:1370 +0x44
  net/http.(*conn).serve()
      /usr/local/Cellar/go/1.6.2/libexec/src/net/http/server.go:1428 +0xe00

Goroutine 76 (running) created at:
  _/Users/abc/dev/graceful.(*Server).Serve()
      /Users/abc/dev/graceful/graceful.go:270 +0x58d
  _/Users/abc/dev/graceful.TestGracefulRunTimesOut.func1()
      /Users/abc/dev/graceful/graceful_test.go:151 +0x146

Goroutine 108 (running) created at:
  net/http.(*Server).Serve()
      /usr/local/Cellar/go/1.6.2/libexec/src/net/http/server.go:2137 +0x4d1
  _/Users/abc/dev/graceful.(*Server).Serve()
      /Users/abc/dev/graceful/graceful.go:282 +0x867
  _/Users/abc/dev/graceful.TestGracefulRunTimesOut.func1()
```