### PR TITLE
ISSUE #85: TCP Keep Alive cannot wrap TLS

### DIFF
--- a/http2_test.go
+++ b/http2_test.go
@@ -65,7 +65,7 @@ func TestHTTP2ListenAndServeTLS(t *testing.T) {
 	var srv *Server
 	go func() {
 		// set timeout of 0 to test idle connection closing
-		srv = &Server{Timeout: 0, Server: server, interrupt: c}
+		srv = &Server{Timeout: 0, TCPKeepAlive: 1 * time.Minute, Server: server, interrupt: c}
 		srv.ListenAndServeTLS("test-fixtures/cert.crt", "test-fixtures/key.pem")
 		wg.Done()
 	}()
@@ -98,7 +98,7 @@ func TestHTTP2ListenAndServeTLSConfig(t *testing.T) {
 	server2 := createServer()
 
 	go func() {
-		srv := &Server{Timeout: killTime, Server: server2, interrupt: c}
+		srv := &Server{Timeout: killTime, TCPKeepAlive: 1 * time.Minute, Server: server2, interrupt: c}
 
 		cert, err := tls.LoadX509KeyPair("test-fixtures/cert.crt", "test-fixtures/key.pem")
 


### PR DESCRIPTION
Order matters when enabling TCP Keep Alives. Keep alives need to
be configured before wrapping them with a TLS Listener. In the current
implementation the TCP Keep Alive listener wraps after TLS is enabled
and TLS Listener doesn't have methods to access the lower layer TCP
behavior.

1. remove the TCP Keep Alive Listener from Serve
2. re-add TCP Keep Alive after creating a tcp Listener but before wrapping in TLS
3. update TLS unit tests to always specify TCPKeepAlive values to catch
   regressions.