### PR TITLE
Fix data race around Timeout in Stop() and shutdown()

### DIFF
--- a/graceful.go
+++ b/graceful.go
@@ -75,6 +75,9 @@ type Server struct {
 	// stopLock is used to protect against concurrent calls to Stop
 	stopLock sync.Mutex
 
+	// timeoutLock is used to protect access to srv.Timeout
+	timeoutLock sync.RWMutex
+
 	// stopChan is the channel on which callers may block while waiting for
 	// the server to stop.
 	stopChan chan struct{}
@@ -335,7 +338,9 @@ func (srv *Server) Stop(timeout time.Duration) {
 	srv.stopLock.Lock()
 	defer srv.stopLock.Unlock()
 
+	srv.timeoutLock.Lock()
 	srv.Timeout = timeout
+	srv.timeoutLock.Unlock()
 	interrupt := srv.interruptChan()
 	interrupt <- syscall.SIGINT
 }
@@ -458,10 +463,14 @@ func (srv *Server) shutdown(shutdown chan chan struct{}, kill chan struct{}) {
 	done := make(chan struct{})
 	shutdown <- done
 
-	if srv.Timeout > 0 {
+	srv.timeoutLock.RLock()
+	timeout := srv.Timeout
+	srv.timeoutLock.RUnlock()
+
+	if timeout > 0 {
 		select {
 		case <-done:
-		case <-time.After(srv.Timeout):
+		case <-time.After(timeout):
 			close(kill)
 		}
 	} else {


### PR DESCRIPTION
Ran into this data race; fixed by protecting access to `Timeout` var with a lock.

```
WARNING: DATA RACE
Write at 0x00c4200c2dc8 by goroutine 24:
  github.com/tylerb/graceful.(*Server).Stop()
      src/github.com/tylerb/graceful/graceful.go:338 +0x83

Previous read at 0x00c4200c2dc8 by goroutine 9:
  github.com/tylerb/graceful.(*Server).shutdown()
     src/github.com/tylerb/graceful/graceful.go:461 +0xab
  github.com/tylerb/graceful.(*Server).Serve()
      src/github.com/tylerb/graceful/graceful.go:322 +0x4e0
```
