### PR TITLE
Fix race condition on timeout between shutdown() and Stop()

### DIFF
--- a/graceful.go
+++ b/graceful.go
@@ -455,6 +455,8 @@ func (srv *Server) shutdown(shutdown chan chan struct{}, kill chan struct{}) {
 	done := make(chan struct{})
 	shutdown <- done
 
+	srv.stopLock.Lock()
+	defer srv.stopLock.Unlock()
 	if srv.Timeout > 0 {
 		select {
 		case <-done:


### PR DESCRIPTION
This PR is shorter than #93 but should do the same thing.
As we are shutting down, there should be no issue using the `stopLock` for this purpose.
It's also a rebased version that can be merged right away.