### PR TITLE
Interrupted locking mechanism

### DIFF
--- a/graceful.go
+++ b/graceful.go
@@ -423,7 +423,7 @@ func (srv *Server) interruptChan() chan os.Signal {
 }
 
 func (srv *Server) handleInterrupt(interrupt chan os.Signal, quitting chan struct{}, listener net.Listener) {
-	for range interrupt {
+	for _ = range interrupt {
 		srv.interruptedLock.Lock()
 		if srv.Interrupted {
 			srv.logf("already shutting down")


### PR DESCRIPTION
The following commit introduces a lock around the Interrupted state.
Introduction of the lock helps prevent race conditions where accessing
internal state at the same time as the Server.handleInterrupt.

Ideally I would prefer to handle the lock outside of this, but because
an internal state is made public via the struct and we have logic
that depends on that, we're a bit limited on how to fix this.