### PR TITLE
Fix: graceful never close use <-s.StopChan()

### DIFF
--- a/graceful.go
+++ b/graceful.go
@@ -473,6 +473,10 @@ func (srv *Server) shutdown(shutdown chan chan struct{}, kill chan struct{}) {
 	srv.chanLock.Lock()
 	if srv.stopChan != nil {
 		close(srv.stopChan)
+	}else {
+		// Fix: stopChan may not init, so if shutdown finish, anyone else use StopChan to wait. it will nevery closed.
+		srv.stopChan = make(chan struct{})
+		close(srv.stopChan)
 	}
 	srv.chanLock.Unlock()
 }


### PR DESCRIPTION
we use gracefull in my project and use <-s.StopChan() to wait service gracefully closed.
but it never return. i got a afternoon to figure out way. yeah, i think it is a bug.

reason: 
// Fix: stopChan may not init, so if shutdown finish, anyone else use StopChan to wait. it will nevery closed.